### PR TITLE
Add ability to abort

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-module.exports = (fn, limit, interval) => {
+const pThrottle = (fn, limit, interval) => {
 	if (!Number.isFinite(limit)) {
 		throw new TypeError('Expected `limit` to be a finite number');
 	}
@@ -55,10 +55,18 @@ module.exports = (fn, limit, interval) => {
 		timeouts.clear();
 
 		for (const x of queue) {
-			x.reject(new Error('Throttled function aborted'));
+			x.reject(new pThrottle.AbortError('Throttled function aborted'));
 		}
 		queue.length = 0;
 	};
 
 	return throttled;
 };
+
+pThrottle.AbortError = class AbortError extends Error {
+	constructor(message) { // eslint-disable-line no-useless-constructor
+		super(message);
+	}
+};
+
+module.exports = pThrottle;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = (fn, limit, interval) => {
 	}
 
 	const queue = [];
-	const timeouts = [];
+	const timeouts = new Set();
 	let activeCount = 0;
 
 	const next = () => {
@@ -22,13 +22,10 @@ module.exports = (fn, limit, interval) => {
 				next();
 			}
 
-			const i = timeouts.indexOf(id);
-			if (i !== -1) {
-				timeouts.splice(i, 1);
-			}
+			timeouts.delete(id);
 		}, interval);
 
-		timeouts.push(id);
+		timeouts.add(id);
 
 		const x = queue.shift();
 		x.resolve(fn.apply(x.self, x.args));
@@ -55,6 +52,8 @@ module.exports = (fn, limit, interval) => {
 		for (const id of timeouts) {
 			clearTimeout(id);
 		}
+		timeouts.clear();
+
 		for (const x of queue) {
 			x.reject(new Error('Throttled function aborted'));
 		}

--- a/index.js
+++ b/index.js
@@ -9,29 +9,38 @@ module.exports = (fn, limit, interval) => {
 	}
 
 	const queue = [];
+	const timeouts = [];
 	let activeCount = 0;
 
 	const next = () => {
 		activeCount++;
 
-		setTimeout(() => {
+		const id = setTimeout(() => {
 			activeCount--;
 
 			if (queue.length > 0) {
 				next();
 			}
+
+			const i = timeouts.indexOf(id);
+			if (i !== -1) {
+				timeouts.splice(i, 1);
+			}
 		}, interval);
+
+		timeouts.push(id);
 
 		const x = queue.shift();
 		x.resolve(fn.apply(x.self, x.args));
 	};
 
-	return function () {
+	const throttled = function () {
 		const args = arguments;
 
-		return new Promise(resolve => {
+		return new Promise((resolve, reject) => {
 			queue.push({
 				resolve,
+				reject,
 				args,
 				self: this
 			});
@@ -41,4 +50,16 @@ module.exports = (fn, limit, interval) => {
 			}
 		});
 	};
+
+	throttled.abort = () => {
+		for (const id of timeouts) {
+			clearTimeout(id);
+		}
+		for (const x of queue) {
+			x.reject(new Error('Throttled function aborted'));
+		}
+		queue.length = 0;
+	};
+
+	return throttled;
 };

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Timespan for `limit`.
 
 ### throttledFn.abort()
 
-Abort pending executions (all unresolved promises are rejected).
+Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` custom error.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,9 @@ Type: `number`
 
 Timespan for `limit`.
 
+### throttledFn.abort()
+
+Abort pending executions (all unresolved promises are rejected).
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -38,6 +38,6 @@ test('can be aborted', async t => {
 	} catch (err) {
 		error = err;
 	}
-	t.is(error.message, 'Throttled function aborted');
+	t.true(error instanceof m.AbortError);
 	t.true(end() < 100);
 });

--- a/test.js
+++ b/test.js
@@ -22,3 +22,22 @@ test('passes arguments through', async t => {
 	const throttled = m(async x => x, 1, 100);
 	t.is(await throttled(fixture), fixture);
 });
+
+test('can be aborted', async t => {
+	const limit = 1;
+	const interval = 10000; // 10 seconds
+	const end = timeSpan();
+	const throttled = m(async () => {}, limit, interval);
+
+	await throttled();
+	const p = throttled();
+	throttled.abort();
+	let error;
+	try {
+		await p;
+	} catch (err) {
+		error = err;
+	}
+	t.is(error.message, 'Throttled function aborted');
+	t.true(end() < 100);
+});


### PR DESCRIPTION
I added a feature to abort all pending executions of a throttled function.

Unresolved promises are rejected and pending timeouts are cleared.

My main motivation for implementing this feature was to allow a Node app to quit normally (without process.exit()).