### PR TITLE
Prevent final invocations from causing an extra wait

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo --fix && ava && tsd-check"
 	},
 	"files": [
 		"index.js",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,19 @@ for (let i = 1; i <= 6; i++) {
 //=> 6: 2s
 ```
 
+Because we don't specify the number of invocations there will be an extra
+`interval` wait at the end. To avoid this you can specify the number of
+invocations when calling `pThrottle`, like so:
+
+```javascript
+const throttled = pThrottle(index => {
+	const secDiff = ((Date.now() - now) / 1000).toFixed();
+	return Promise.resolve(`${index}: ${secDiff}s`);
+}, 2, 1000, { numberOfInvocations: 6 });
+```
+
+This way, the program will exit without waiting an extra `interval` after the
+`n` final calls, where `n == limit`
 
 ## API
 


### PR DESCRIPTION
This PR aims to address sindresorhus/p-throttle#6

## Problem
An extra wait for `interval` happens at the end of all the invocations

## Cause
The number of invocations isn't specified ahead of time and each invocation is pushed onto the `queue` as the `throttle` function is called. This makes it impossible for the code to know which invocations are the last and avoid the last calls to `setTimeout`

## Fix
An extra parameter `opts`. This was chosen to be an `object` because it is meant for 1 or more optional parameters. 
Knowing the amount of invocations before hand we can avoid the last `n` calls to `setTimeout`, where `n` is `limit`.

## Alternative
The `fn` parameter could be either a function or an `Array` of functions. Depending on which it would behave as with the new parameter.

The extra parameter is more flexible. Let's say that we had an array of functions but only wanted to run a subset of them. With the array approach we would have to create a new array with the first `x` functions to execute. With the extra parameter we merely specify a number, without creating an extra array

---

## Help Wanted
There is still one issue: Avajs seems to not wait for the last timeout, so I couldn't reproduce this in tests and add more tests to verify the functionality. Would appreciate help here if automated tests are desired for this.

This is visible however with the example code @pvdlg provided in the linked issue. Change the example to:
```javascript
// File test.js

const pThrottle = require('p-throttle');
const numberOfInvocations = 6
const now = Date.now();

const throttled = pThrottle(i => {
	const secDiff = ((Date.now() - now) / 1000).toFixed();
	return Promise.resolve(`${i}: ${secDiff}s`);
}, 2, 1000, { numberOfInvocations });

for (let i = 1; i <= numberOfInvocations; i++) {
	throttled(i).then(console.log);
}
```

We get:
```text
node test.js

1: 0s
2: 0s
3: 1s
4: 1s
5: 2s
6: 2s
// Exits with no extra wait!
```