### PR TITLE
Improve performance and memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	],
 	"devDependencies": {
 		"ava": "^0.25.0",
+		"delay": "^4.1.0",
 		"in-range": "^1.0.0",
 		"time-span": "^1.0.0",
 		"tsd-check": "^0.2.1",


### PR DESCRIPTION
 - [x] Uses [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) instead of plain object & array for storing promise cancelers.
 - [x] Does **not** use `Timeout`s for checking for new items in the queue.

We could gain more even performance if we allowed users to disable aborting.

Fixes #2
Fixes #6
Closes #9
Closes #10