### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,9 @@ export class AbortError extends Error {
 }
 
 /**
- * Returns a throttled version of `fn`.
+ * [Throttle](https://css-tricks.com/debouncing-throttling-explained-examples/) promise-returning/async/normal functions.
  *
- * @param input - Promise-returning/async function or a normal function.
+ * @param fn - Promise-returning/async function or a normal function.
  * @param limit - Maximum number of calls within an `interval`.
  * @param interval - Timespan for `limit` in milliseconds.
  * @returns A throttled version of `fn`.
@@ -28,7 +28,7 @@ export class AbortError extends Error {
  * }
  */
 export default function<TArguments extends any[], TReturn>(
-	input: (...arguments: TArguments) => PromiseLike<TReturn> | TReturn,
+	fn: (...arguments: TArguments) => PromiseLike<TReturn> | TReturn,
 	limit: number,
 	interval: number
 ): ThrottledFunction<TArguments, TReturn>;
@@ -36,5 +36,8 @@ export default function<TArguments extends any[], TReturn>(
 export type ThrottledFunction<TArguments extends any[], TReturn> = ((
 	...args: TArguments
 ) => Promise<TReturn>) & {
+	/**
+	 * Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
+	 */
 	abort(): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 export class AbortError extends Error {
+	readonly name: 'AbortError';
+
 	/**
 	 * Abort pending execution. All unresolved promised are rejected with a `AbortError` error.
 	 */
@@ -25,4 +27,14 @@ export class AbortError extends Error {
  * 	throttled(i).then(console.log);
  * }
  */
-export default function <T extends Function>(input: T, limit: number, interval: number): T;
+export default function<TArguments extends any[], TReturn>(
+	input: (...arguments: TArguments) => PromiseLike<TReturn> | TReturn,
+	limit: number,
+	interval: number
+): ThrottledFunction<TArguments, TReturn>;
+
+export type ThrottledFunction<TArguments extends any[], TReturn> = ((
+	...args: TArguments
+) => Promise<TReturn>) & {
+	abort(): void;
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,15 @@ export class AbortError extends Error {
 	constructor();
 }
 
+export type ThrottledFunction<Arguments extends unknown[], Return> = ((
+	...arguments: Arguments
+) => Promise<Return>) & {
+	/**
+	 * Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
+	 */
+	abort(): void;
+};
+
 /**
  * [Throttle](https://css-tricks.com/debouncing-throttling-explained-examples/) promise-returning/async/normal functions.
  *
@@ -27,17 +36,8 @@ export class AbortError extends Error {
  * 	throttled(i).then(console.log);
  * }
  */
-export default function<TArguments extends any[], TReturn>(
-	fn: (...arguments: TArguments) => PromiseLike<TReturn> | TReturn,
+export default function<Arguments extends unknown[], Return>(
+	fn: (...arguments: Arguments) => PromiseLike<Return> | Return,
 	limit: number,
 	interval: number
-): ThrottledFunction<TArguments, TReturn>;
-
-export type ThrottledFunction<TArguments extends any[], TReturn> = ((
-	...args: TArguments
-) => Promise<TReturn>) & {
-	/**
-	 * Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
-	 */
-	abort(): void;
-};
+): ThrottledFunction<Arguments, Return>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,15 +1,26 @@
 import {expectType} from 'tsd-check';
-import pThrottle, {AbortError} from '.';
+import pThrottle, {AbortError, ThrottledFunction} from '.';
 
-const throttledUnicorn = pThrottle((index: string) => {
-	return '🦄';
-}, 1, 1000);
+const throttledUnicorn = pThrottle(
+	(index: string) => {
+		return '🦄';
+	},
+	1,
+	1000
+);
 
-const throttledLazyUnicorn = pThrottle(async (index: string) => {
-	return '🦄';
-}, 1, 1000);
+const throttledLazyUnicorn = pThrottle(
+	async (index: string) => {
+		return '🦄';
+	},
+	1,
+	1000
+);
 
 expectType<Error>(new AbortError());
 
-expectType<string>(throttledUnicorn('foo'));
-expectType<Promise<string>>(throttledLazyUnicorn('foo'));
+expectType<ThrottledFunction<[string], string>>(throttledUnicorn);
+expectType<ThrottledFunction<[string], string>>(throttledLazyUnicorn);
+
+throttledUnicorn.abort();
+throttledLazyUnicorn.abort();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,17 +2,13 @@ import {expectType} from 'tsd-check';
 import pThrottle, {AbortError, ThrottledFunction} from '.';
 
 const throttledUnicorn = pThrottle(
-	(index: string) => {
-		return '🦄';
-	},
+	(index: string) => '🦄',
 	1,
 	1000
 );
 
 const throttledLazyUnicorn = pThrottle(
-	async (index: string) => {
-		return '🦄';
-	},
+	async (index: string) => '🦄',
 	1,
 	1000
 );


### PR DESCRIPTION
Fix return type of `p-throttle` to signal that the throttled function always returns a `Promise` and that there is a `cancel` method on the returned function.