### PR TITLE
Clear timeout after aborting pending executions

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ const pThrottle = (fn, limit, interval) => {
 
 	throttled.abort = () => {
 		for (const timeout of queue.keys()) {
+			clearTimeout(timeout);
 			queue.get(timeout)(new AbortError());
 		}
 


### PR DESCRIPTION
abort() doesn't clear the timeout of pending executions. thus all executions will execute after abortion.