### PR TITLE
Fix TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,10 +7,12 @@ declare class AbortErrorClass extends Error {
 	constructor();
 }
 
+type PromiseResolve<ValueType> = ValueType extends PromiseLike<infer ValueType> ? Promise<ValueType> : Promise<ValueType>;
+
 declare namespace pThrottle {
 	type ThrottledFunction<Argument, ReturnValue> = ((
 		...arguments: Argument[]
-	) => Promise<ReturnValue>) & {
+	) => PromiseResolve<ReturnValue>) & {
 		/**
 		Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,9 @@ declare class AbortErrorClass extends Error {
 }
 
 declare namespace pThrottle {
-	type ThrottledFunction<FunctionType extends (...args: any) => any> = ((
-		...arguments: Parameters<FunctionType>
-	) => ReturnType<FunctionType>) & {
+	type ThrottledFunction<Argument, ReturnValue> = ((
+		...arguments: Argument[]
+	) => Promise<ReturnValue>) & {
 		/**
 		Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
 		*/
@@ -30,11 +30,6 @@ declare namespace pThrottle {
 	}
 
 	type AbortError = AbortErrorClass;
-
-	/**
-	@param fn - Promise-returning/async function or a normal function.
-	*/
-	type Throttle<FunctionType extends (...args: any) => any> = (fn: (...arguments: Parameters<FunctionType>) => ReturnType<FunctionType>) => ThrottledFunction<FunctionType>;
 }
 
 declare const pThrottle: {
@@ -65,9 +60,9 @@ declare const pThrottle: {
 	}
 	```
 	*/
-	<FunctionType extends (...args: any) => any>(
+	(
 		options: pThrottle.Options
-	): pThrottle.Throttle<FunctionType>;
+	): <Argument, ReturnValue>(function_: (...arguments: Argument[]) => ReturnValue) => pThrottle.ThrottledFunction<Argument, ReturnValue>;
 };
 
 export = pThrottle;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,7 +14,7 @@ const throttledLazyUnicorn = pThrottle({
 
 expectType<AbortError>(new AbortError());
 
-expectType<ThrottledFunction<string, string>(throttledUnicorn);
+expectType<ThrottledFunction<string, string>>(throttledUnicorn);
 expectType<ThrottledFunction<string, Promise<string>>>(throttledLazyUnicorn);
 
 throttledUnicorn.abort();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectAssignable} from 'tsd';
 import pThrottle = require('./index.js');
 import {AbortError, ThrottledFunction} from './index.js';
 
@@ -14,8 +14,8 @@ const throttledLazyUnicorn = pThrottle({
 
 expectType<AbortError>(new AbortError());
 
-expectType<ThrottledFunction<string, string>>(throttledUnicorn);
-expectType<ThrottledFunction<string, string>>(throttledLazyUnicorn);
+expectAssignable<ThrottledFunction<(index: string) => string>>(throttledUnicorn);
+expectAssignable<ThrottledFunction<(index: string) => string>>(throttledLazyUnicorn);
 
 throttledUnicorn.abort();
 throttledLazyUnicorn.abort();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectType} from 'tsd';
 import pThrottle = require('./index.js');
 import {AbortError, ThrottledFunction} from './index.js';
 
@@ -14,8 +14,8 @@ const throttledLazyUnicorn = pThrottle({
 
 expectType<AbortError>(new AbortError());
 
-expectAssignable<ThrottledFunction<(index: string) => string>>(throttledUnicorn);
-expectAssignable<ThrottledFunction<(index: string) => string>>(throttledLazyUnicorn);
+expectType<ThrottledFunction<string, string>(throttledUnicorn);
+expectType<ThrottledFunction<string, Promise<string>>>(throttledLazyUnicorn);
 
 throttledUnicorn.abort();
 throttledLazyUnicorn.abort();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectType} from 'tsd';
 import pThrottle = require('./index.js');
 import {AbortError, ThrottledFunction} from './index.js';
 
@@ -14,8 +14,8 @@ const throttledLazyUnicorn = pThrottle({
 
 expectType<AbortError>(new AbortError());
 
-expectAssignable<ThrottledFunction<(index: string) => string>>(throttledUnicorn);
-expectAssignable<ThrottledFunction<(index: string) => string>>(throttledLazyUnicorn);
+expectType<ThrottledFunction<string, string>>(throttledUnicorn);
+expectType<ThrottledFunction<string, string>>(throttledLazyUnicorn);
 
 throttledUnicorn.abort();
 throttledLazyUnicorn.abort();


### PR DESCRIPTION
In #22, I accidentally broke the TypeScript typings in a bizarre way so that `expectAssignable` was wide enough to test the code pre-PR but also hid the newly introduced error.