### PR TITLE
Add tests for `this` context

### DIFF
--- a/test.js
+++ b/test.js
@@ -70,5 +70,6 @@ test('`this` is preserved in throttled function', async t => {
 	const thisFixture = new FixtureClass();
 
 	t.is(await thisFixture.getThis(), thisFixture);
-	await t.notThrowsAsync(() => thisFixture.foo());
+	await t.notThrowsAsync(thisFixture.foo());
+	t.is(await thisFixture.foo(), fixture);
 });

--- a/test.js
+++ b/test.js
@@ -46,21 +46,21 @@ test('can be aborted', async t => {
 	t.true(end() < 100);
 });
 
-test('`this` is preserved in pThrottle fn', async t => {
+test('`this` is preserved in throttled function', async t => {
 	class FixtureClass {
 		constructor() {
 			this._foo = fixture;
 		}
 
 		foo() {
-			// If `this` is not preserved by pThrottle()
+			// If `this` is not preserved by `pThrottle()`
 			// then `this` will be undefined and accesing `this._foo` will throw.
 			return this._foo;
 		}
 
 		getThis() {
-			// If `this` is not preserved by pThrottle()
-			// then `this` will be undefined
+			// If `this` is not preserved by `pThrottle()`
+			// then `this` will be undefined.
 			return this;
 		}
 	}


### PR DESCRIPTION
Similar to https://github.com/sindresorhus/p-debounce/pull/16

The issue in `pDebounce` did not happen with `pThrottle`, but there is a risk it could in the future.  So I added a test to help protect against it.

~~I also strengthened pThrottle() implementation so that if it is transpiled to ES5, `this` context that throttled fn is called is preserved.~~ (Edit: I dropped this change based on comment https://github.com/sindresorhus/p-throttle/pull/25#discussion_r561542921 below)