### PR TITLE
Support getting current Promise queue length

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,14 +17,14 @@ export type ThrottledFunction<Argument extends readonly unknown[], ReturnValue> 
 	isEnabled: boolean;
 
 	/**
+	The number of queued items waiting to be executed.
+	*/
+	readonly queueSize: number;
+
+	/**
 	Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
 	*/
 	abort(): void;
-
-	/**
-	The number of queued items waiting to be executed.
-	*/
-	queueSize(): number;
 };
 
 export interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,11 @@ export type ThrottledFunction<Argument extends readonly unknown[], ReturnValue> 
 		Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
 		*/
 	abort(): void;
+
+	/**
+		The current length of the promise queue.
+		*/
+	queueLength(): number;
 };
 
 export interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,9 +22,9 @@ export type ThrottledFunction<Argument extends readonly unknown[], ReturnValue> 
 	abort(): void;
 
 	/**
-		The current length of the promise queue.
+		The number of queued items waiting to be executed.
 		*/
-	queueLength(): number;
+	queueSize(): number;
 };
 
 export interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,20 +10,20 @@ type PromiseResolve<ValueType> = ValueType extends PromiseLike<infer ValueType> 
 export type ThrottledFunction<Argument extends readonly unknown[], ReturnValue> = ((...arguments: Argument) => PromiseResolve<ReturnValue>)
 & {
 	/**
-		Whether future function calls should be throttled or count towards throttling thresholds.
+	Whether future function calls should be throttled or count towards throttling thresholds.
 
-		@default true
-		*/
+	@default true
+	*/
 	isEnabled: boolean;
 
 	/**
-		Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
-		*/
+	Abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
+	*/
 	abort(): void;
 
 	/**
-		The number of queued items waiting to be executed.
-		*/
+	The number of queued items waiting to be executed.
+	*/
 	queueSize(): number;
 };
 

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ export default function pThrottle({limit, interval, strict}) {
 
 		throttled.isEnabled = true;
 
-		throttled.queueLength = () => queue.size;
+		throttled.queueSize = () => queue.size;
 
 		return throttled;
 	};

--- a/index.js
+++ b/index.js
@@ -92,6 +92,8 @@ export default function pThrottle({limit, interval, strict}) {
 
 		throttled.isEnabled = true;
 
+		throttled.queueLength = () => queue.size;
+
 		return throttled;
 	};
 }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,11 @@ export default function pThrottle({limit, interval, strict}) {
 
 		throttled.isEnabled = true;
 
-		throttled.queueSize = () => queue.size;
+		Object.defineProperty(throttled, 'queueSize', {
+			get() {
+				return queue.size;
+			},
+		});
 
 		return throttled;
 	};

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -41,3 +41,4 @@ strictThrottledLazyUnicorn.abort();
 throttledTaggedUnicorn.abort();
 
 expectType<boolean>(throttledUnicorn.isEnabled);
+expectType<number>(throttledUnicorn.queueSize);

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,13 @@ Default: `true`
 
 Whether future function calls should be throttled and count towards throttling thresholds.
 
+### throttledFn.queueLength()
+
+Type: `Function`\
+Returns: `number`
+
+Returns the current length of the promise queue.
+
 ## Related
 
 - [p-debounce](https://github.com/sindresorhus/p-debounce) - Debounce promise-returning & async functions

--- a/readme.md
+++ b/readme.md
@@ -96,10 +96,9 @@ Default: `true`
 
 Whether future function calls should be throttled and count towards throttling thresholds.
 
-### throttledFn.queueSize()
+### throttledFn.queueSize
 
-Type: `Function`\
-Returns: `number`
+Type: `number`
 
 The number of queued items waiting to be executed.
 

--- a/readme.md
+++ b/readme.md
@@ -96,12 +96,12 @@ Default: `true`
 
 Whether future function calls should be throttled and count towards throttling thresholds.
 
-### throttledFn.queueLength()
+### throttledFn.queueSize()
 
 Type: `Function`\
 Returns: `number`
 
-Returns the current length of the promise queue.
+The number of queued items waiting to be executed.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -28,17 +28,17 @@ test('queue size', async t => {
 	const throttled = pThrottle({limit, interval})(() => Date.now());
 	const promises = [];
 
-	t.is(throttled.queueSize(), 0);
+	t.is(throttled.queueSize, 0);
 
 	for (let index = 0; index < limit; index++) {
 		promises.push(throttled());
 	}
 
-	t.is(throttled.queueSize(), limit);
+	t.is(throttled.queueSize, limit);
 
 	await Promise.all(promises);
 
-	t.is(throttled.queueSize(), 0);
+	t.is(throttled.queueSize, 0);
 });
 
 test('strict mode', async t => {

--- a/test.js
+++ b/test.js
@@ -22,6 +22,25 @@ test('main', async t => {
 	}));
 });
 
+test('queue length', async t => {
+	const limit = 10;
+	const interval = 100;
+	const throttled = pThrottle({limit, interval})(() => Date.now());
+	const promises = [];
+
+	t.true(throttled.queueLength() === 0);
+
+	for (let index = 0; index < limit; index++) {
+		promises.push(throttled());
+	}
+
+	t.true(throttled.queueLength() === limit);
+
+	await Promise.all(promises);
+
+	t.true(throttled.queueLength() === 0);
+});
+
 test('strict mode', async t => {
 	const totalRuns = 100;
 	const limit = 5;

--- a/test.js
+++ b/test.js
@@ -22,23 +22,23 @@ test('main', async t => {
 	}));
 });
 
-test('queue length', async t => {
+test('queue size', async t => {
 	const limit = 10;
 	const interval = 100;
 	const throttled = pThrottle({limit, interval})(() => Date.now());
 	const promises = [];
 
-	t.true(throttled.queueLength() === 0);
+	t.is(throttled.queueSize(), 0);
 
 	for (let index = 0; index < limit; index++) {
 		promises.push(throttled());
 	}
 
-	t.true(throttled.queueLength() === limit);
+	t.is(throttled.queueSize(), limit);
 
 	await Promise.all(promises);
 
-	t.true(throttled.queueLength() === 0);
+	t.is(throttled.queueSize(), 0);
 });
 
 test('strict mode', async t => {


### PR DESCRIPTION
Useful in cases e.g. a consuming program wants to check for promise-queue congestion, for reporting on growing backlogs (e.g. In my case exposing the current promise-queue length as a custom Prometheus metric to alert if the process is seeing latency in churning through what _should_ be a quick-to-process set of queued promises.)