### PR TITLE
Call `setTimeout` only when execution is delayed

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,13 @@ export default function pThrottle({limit, interval, strict}) {
 					queue.delete(timeoutId);
 				};
 
-				timeoutId = setTimeout(execute, getDelay());
-
-				queue.set(timeoutId, reject);
+				const delay = getDelay();
+				if (delay > 0) {
+					timeoutId = setTimeout(execute, delay);
+					queue.set(timeoutId, reject);
+				} else {
+					execute();
+				}
 			});
 		};
 

--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ test('main', async t => {
 test('queue size', async t => {
 	const limit = 10;
 	const interval = 100;
+	const delayedExecutions = 20;
 	const throttled = pThrottle({limit, interval})(() => Date.now());
 	const promises = [];
 
@@ -34,7 +35,13 @@ test('queue size', async t => {
 		promises.push(throttled());
 	}
 
-	t.is(throttled.queueSize, limit);
+	t.is(throttled.queueSize, 0);
+
+	for (let index = 0; index < delayedExecutions; index++) {
+		promises.push(throttled());
+	}
+
+	t.is(throttled.queueSize, delayedExecutions);
 
 	await Promise.all(promises);
 


### PR DESCRIPTION
- Call `setTimeout` only when execution is delayed

Fixes #43 