### PR TITLE
feat: support AbortSignal to listen to execution abortion

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,14 +90,18 @@ export type Options = {
 		console.log('Executing...');
 	});
 
+	const throttled = throttle(() => {
+		console.log('Executing...');
+	});
+
 	await throttled();
 	await throttled();
-	const promise = throttled();
 	abortController.abort();
+	let promise = throttled();
 	await promise;
 	//=> Executing...
 	//=> Executing...
-	//=> Promise rejected with AbortError
+	//=> Promise rejected with AbortError (DOMException)
 	```
 	*/
 	readonly signal?: AbortSignal;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,33 @@ export type Options = {
 	```
 	*/
 	readonly onDelay?: () => void;
+
+	/**
+	`AbortSignal` to abort pending executions. All unresolved promises are rejected with a `pThrottle.AbortError` error.
+
+	@example
+	```
+	const abortController = new AbortController();
+
+	const throttled = pThrottle({
+		limit: 3,
+		interval: 1000,
+		signal: abortController.signal
+	})(() => {
+		console.log('Executing...');
+	});
+
+	await throttled();
+	await throttled();
+	const promise = throttled();
+	abortController.abort();
+	await promise;
+	//=> Executing...
+	//=> Executing...
+	//=> Promise rejected with AbortError
+	```
+	*/
+	readonly signal?: AbortSignal;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ export class AbortError extends Error {
 	}
 }
 
-export default function pThrottle({limit, interval, strict, onDelay}) {
+export default function pThrottle({limit, interval, strict, onDelay, signal}) {
 	if (!Number.isFinite(limit)) {
 		throw new TypeError('Expected `limit` to be a finite number');
 	}
@@ -108,6 +108,10 @@ export default function pThrottle({limit, interval, strict, onDelay}) {
 				return queue.size;
 			},
 		});
+
+		if (signal) {
+			signal.addEventListener('abort', throttled.abort);
+		}
 
 		return throttled;
 	};

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,38 @@ await throttled();
 //=> Executing...
 ```
 
+##### signal
+
+Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+
+An optional signal to listen for abort events. If the signal becomes aborted, all pending and future calls are rejected with a `pThrottle.AbortError` error.
+
+You can abort the promises using an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController):
+
+```js
+import pThrottle from 'p-throttle';
+
+const abortController = new AbortController();
+const throttle = pThrottle({
+	limit: 2,
+	interval: 1000,
+	signal: abortController.signal
+});
+
+const throttled = throttle(() => {
+	console.log('Executing...');
+});
+
+await throttled();
+await throttled();
+abortController.abort();
+let promise = throttled();
+await promise;
+//=> Executing...
+//=> Executing...
+//=> Promise rejected with AbortError (DOMException)
+```
+
 ### throttle(function_)
 
 Returns a throttled version of `function_`.

--- a/test.js
+++ b/test.js
@@ -151,6 +151,30 @@ test('can be aborted', async t => {
 	t.true(end() < 100);
 });
 
+test('can listen to AbortSignal to abort execution', async t => {
+	const limit = 1;
+	const interval = 10_000; // 10 seconds
+	const end = timeSpan();
+	const abortController = new AbortController();
+	const throttled = pThrottle({limit, interval, signal: abortController.signal})(async x => x);
+
+	const one = await throttled(1);
+	const promise = throttled(2);
+	abortController.abort();
+	let error;
+	let endValue;
+	try {
+		endValue = await promise;
+	} catch (error_) {
+		error = error_;
+	}
+
+	t.true(error instanceof AbortError);
+	t.true(end() < 100);
+	t.true(one === 1);
+	t.true(endValue === undefined);
+});
+
 test('can be disabled', async t => {
 	let counter = 0;
 


### PR DESCRIPTION
Add `signal` option to listen to execution abortion. When the signal is aborted, all future and pending calls are aborted.