### PR TITLE
Fix Synchroniously thrown errors in the throttled function crash js because they are not caught in the setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,12 @@ export default function pThrottle({limit, interval, strict, signal, onDelay}) {
 			let timeoutId;
 			return new Promise((resolve, reject) => {
 				const execute = () => {
-					resolve(function_.apply(this, arguments_));
+					try {
+						resolve(function_.apply(this, arguments_));
+					} catch (error) {
+						reject(error);
+					}
+
 					queue.delete(timeoutId);
 				};
 

--- a/test.js
+++ b/test.js
@@ -439,3 +439,39 @@ test('onDelay', async t => {
 
 	await Promise.all(promises);
 });
+
+test('supports errors in the throttled function', async t => {
+	const limit = 1;
+	const interval = 100;
+	const pause = 1;
+	const throttle = pThrottle({limit, interval});
+
+	const syncFunction = () => {
+		throw new Error('test error');
+	};
+
+	const throttledSync = throttle(syncFunction);
+
+	const asyncFunction = async () => {
+		await delay(pause);
+		throw new Error('test error');
+	};
+
+	const throttledAsync = throttle(asyncFunction);
+
+	await throttle(() => {})(); // Create a delay
+
+	try {
+		await throttledSync(); // Has delay
+	} catch (error) {
+		t.is(error.message, 'test error');
+	}
+
+	try {
+		await throttledAsync(); // Has delay
+	} catch (error) {
+		t.is(error.message, 'test error');
+	}
+
+	t.pass(); // Test passes when errors were passed through correctly and could be caught
+});


### PR DESCRIPTION
Fixes #63 

This approach surrounds the maybe synchroniously throwing function with a try catch to be able to reject a thrown error.

An alternative approach that would maybe be more beautiful but a bigger change in the library would be to make "throttled" in the returned function an async function and await the delay first, then all the function. That way the sync error would also be rejected by the returned promise.